### PR TITLE
feat(storage): add friend_ids column to agent_status table

### DIFF
--- a/packages/agentsociety/agentsociety/storage/database.py
+++ b/packages/agentsociety/agentsociety/storage/database.py
@@ -237,6 +237,7 @@ class DatabaseWriter:
                             "t": row.t,
                             "lng": row.lng,
                             "lat": row.lat,
+                            "friend_ids": row.friend_ids,
                             "parent_id": row.parent_id,
                             "action": row.action,
                             "status": row.status,

--- a/packages/agentsociety/agentsociety/storage/model.py
+++ b/packages/agentsociety/agentsociety/storage/model.py
@@ -52,11 +52,12 @@ def agent_status(table_name: str):
         Column("t", Float),
         Column("lng", Float, nullable=True),
         Column("lat", Float, nullable=True),
+        Column("friend_ids", JSON),
         Column("parent_id", Integer),
         Column("action", String),
         Column("status", JSON),
         Column("created_at", TIMESTAMP(timezone=True)),
-    ), ["id", "day", "t", "lng", "lat", "parent_id", "action", "status", "created_at"]
+    ), ["id", "day", "t", "lng", "lat", "friend_ids", "parent_id", "action", "status", "created_at"]
 
 
 def agent_survey(table_name: str):


### PR DESCRIPTION
- Add friend_ids JSON column to store agent social networks
- Update write_statuses to persist friend_ids data
- Include friend_ids in returned column list

This enables tracking and querying of agent social relationships directly from the database.