### PR TITLE
Add explicit Ollama support as LLM provider

### DIFF
--- a/docs/01-quick-start/01-prerequisites.md
+++ b/docs/01-quick-start/01-prerequisites.md
@@ -26,6 +26,7 @@ To use this framework, you **need access to LLM APIs**. We support multiple prov
 - [ZhipuAI](https://chatglm.cn/)
 - [VolcEngine](https://www.volcengine.com/)
 - [vLLM](https://docs.vllm.ai/en/stable/)
+- [Ollama](https://ollama.ai/)
 
 Actually, the `vLLM` means any LLM inference engine with the [OpenAI API](https://platform.openai.com/docs/api-reference/introduction)-compatible interface.
 You can set the `base_url` and `api_key` in the `llm` section of the configuration to connect to any LLM inference engine or provider.
@@ -100,3 +101,38 @@ You can also use the `CUDA_VISIBLE_DEVICES` environment variable to specify the 
 You should set the `HF_ENDPOINT` environment to `https://hf-mirror.com` to avoid the model download problem if you are in China.
 
 After the vLLM server is running, you can set the `base_url` as the address of the vLLM server with path `/v1` (e.g. `http://your-server-ip:$PORT/v1`) to use it.
+
+### Self-hosted Models by Ollama
+
+Ollama is a lightweight, easy-to-use LLM inference engine that supports running models locally.
+You can use it to self-host your own LLM models for AgentSociety with minimal setup.
+
+Here is how to install and run Ollama:
+
+1. Install Ollama by following the instructions at [https://ollama.ai/](https://ollama.ai/)
+
+2. Download a model (e.g., Llama 2):
+```bash
+ollama pull llama2
+```
+
+3. Start the Ollama server:
+```bash
+ollama serve
+```
+
+4. The server will run on `http://localhost:11434` by default, with OpenAI-compatible API available at `http://localhost:11434/v1`
+
+```{admonition} Important
+:class: important
+Ollama provides an OpenAI-compatible API endpoint at `/v1` which works seamlessly with AgentSociety.
+You don't need to set an API key when using Ollama locally, but you must provide a dummy value in the configuration.
+```
+
+```{admonition} Note
+:class: note
+You can run Ollama on a different host or port by setting environment variables or command-line options.
+See the Ollama documentation for more details on advanced configuration.
+```
+
+After Ollama is running, you can use it in AgentSociety by setting `provider: "ollama"` in your configuration.

--- a/docs/01-quick-start/02-start-your-first-simulation.md
+++ b/docs/01-quick-start/02-start-your-first-simulation.md
@@ -34,7 +34,7 @@ An example configuration file is shown below, you can refer to it to create your
 ``` yaml
 llm:
 - api_key: <API-KEY> # LLM API key
-  base_url: <BASE-URL> # LLM base URL, used for VLLM
+  base_url: <BASE-URL> # LLM base URL, used for VLLM and Ollama
   model: <YOUR-MODEL> # LLM model
   provider: <PROVIDER> # LLM provider
   semaphore: 200 # Semaphore for LLM requests, control the max number of concurrent requests
@@ -56,6 +56,37 @@ exp:
   workflow:
   - day: 1 # The day of the workflow step
     type: run # The type of the workflow step
+```
+
+### Example Configuration for Ollama
+
+If you're using Ollama for local model inference, here's a specific example configuration:
+
+```yaml
+llm:
+- api_key: "dummy" # Ollama doesn't require a real API key, but field is required
+  base_url: "http://localhost:11434/v1" # Default Ollama endpoint (optional, will default to this)
+  model: "llama2" # Your downloaded Ollama model
+  provider: "ollama" # Set provider to ollama
+  semaphore: 200
+env:
+  db:
+    enabled: true
+    db_type: sqlite
+map:
+  file_path: "./data/beijing_map.pb"
+agents:
+  citizens:
+  - agent_class: citizen
+    number: 100
+exp:
+  name: ollama_test
+  environment:
+    start_tick: 28800
+    total_tick: 7200
+  workflow:
+  - day: 1
+    type: run
 ```
 
 ```{admonition} Hint

--- a/examples/config_templates/example_config.yaml
+++ b/examples/config_templates/example_config.yaml
@@ -1,8 +1,8 @@
 llm:
 - api_key: <API-KEY> # LLM API key
-  base_url: <BASE-URL> # LLM base URL, used for VLLM
+  base_url: <BASE-URL> # LLM base URL, used for VLLM and Ollama (optional for Ollama, defaults to http://localhost:11434/v1)
   model: <YOUR-MODEL> # LLM model
-  provider: <PROVIDER> # LLM provider
+  provider: <PROVIDER> # LLM provider (options: openai, deepseek, qwen, zhipuai, siliconflow, volcengine, vllm, ollama)
   semaphore: 200 # Semaphore for LLM requests, control the max number of concurrent requests
 env:
   db:

--- a/packages/agentsociety/agentsociety/llm/llm.py
+++ b/packages/agentsociety/agentsociety/llm/llm.py
@@ -42,6 +42,7 @@ class LLMProviderType(str, Enum):
         - `ZHIPU`: Zhipu.
         - `SILICONFLOW`: SiliconFlow.
         - `VLLM`: VLLM.
+        - `OLLAMA`: Ollama local inference server.
     """
 
     OpenAI = "openai"
@@ -51,6 +52,7 @@ class LLMProviderType(str, Enum):
     SiliconFlow = "siliconflow"
     VolcEngine = "volcengine"
     VLLM = "vllm"
+    Ollama = "ollama"
 
 
 class LLMConfig(BaseModel):
@@ -80,7 +82,7 @@ class LLMConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_configuration(self):
-        if self.provider != LLMProviderType.VLLM and self.base_url is not None:
+        if self.provider not in (LLMProviderType.VLLM, LLMProviderType.Ollama) and self.base_url is not None:
             raise ValueError("base_url is not supported for this provider")
         return self
 
@@ -290,6 +292,9 @@ class LLM:
                 base_url = "https://api.siliconflow.cn/v1"
             elif config.provider == LLMProviderType.VLLM:
                 ...
+            elif config.provider == LLMProviderType.Ollama:
+                if base_url is None:
+                    base_url = "http://localhost:11434/v1"
             elif config.provider == LLMProviderType.ZhipuAI:
                 base_url = "https://open.bigmodel.cn/api/paas/v4/"
             elif config.provider == LLMProviderType.VolcEngine:


### PR DESCRIPTION
## Summary
- Add Ollama as a first-class LLM provider option
- Update configuration validation to support Ollama base_url parameter
- Add comprehensive Ollama documentation and setup instructions
- Include configuration examples for easy Ollama integration

## Changes Made
- Added `Ollama = "ollama"` to LLMProviderType enum
- Modified validation to allow base_url for both VLLM and Ollama providers
- Set default Ollama endpoint to `http://localhost:11434/v1`
- Updated prerequisites documentation with Ollama installation steps
- Added Ollama configuration example to quick start guide
- Enhanced example configuration template with all provider options

## Benefits
- Eliminates confusing vLLM workaround for Ollama users
- Provides simpler setup process compared to vLLM
- Maintains consistent OpenAI-compatible API interface
- Offers automatic model management through Ollama

## Test Plan
- [ ] Verify configuration validation accepts Ollama provider with base_url
- [ ] Test default base_url assignment for Ollama provider
- [ ] Validate configuration examples work with actual Ollama setup
- [ ] Confirm documentation accuracy and completeness