### PR TITLE
fix(docs): 修正 RTD 在 monorepo 下的安装路径

### DIFF
--- a/packages/agentsociety2/.readthedocs.yaml
+++ b/packages/agentsociety2/.readthedocs.yaml
@@ -1,20 +1,21 @@
+# Paths are relative to the repository root (monorepo).
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   apt_packages:
     - graphviz
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: packages/agentsociety2/docs/requirements.txt
     - method: pip
-      path: .
+      path: packages/agentsociety2
       extra_requirements:
         - docs
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: packages/agentsociety2/docs/conf.py
   fail_on_warning: false

--- a/packages/agentsociety2/docs/.readthedocs.yaml
+++ b/packages/agentsociety2/docs/.readthedocs.yaml
@@ -1,4 +1,5 @@
-# ReadTheDocs Configuration File
+# Paths are relative to the repository root (monorepo).
+# Prefer this file or packages/agentsociety2/.readthedocs.yaml (same content).
 version: 2
 
 build:
@@ -18,7 +19,4 @@ python:
 
 sphinx:
   configuration: packages/agentsociety2/docs/conf.py
-
-formats:
-  - pdf
-  - htmlzip
+  fail_on_warning: false


### PR DESCRIPTION
统一 .readthedocs.yaml：从仓库根安装 packages/agentsociety2 与 docs/requirements.txt；移除 pdf/htmlzip 避免多文件上传失败。