### PR TITLE
chore(release): bump version to 2.5.2 / extension 1.5.2

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "AgentSociety CodeQL config"
+
+paths-ignore:
+  - frontend/public/monaco-editor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Git 发版标签：`agentsociety2-v{major}.{minor}.{patch}`（见 `CONTRIBUTING.
 
 ## [Unreleased]
 
+---
+
+## [2.5.2] - 2026-05-29
+
+- **agentsociety2** `2.5.2` · **extension** `1.5.2` · 标签 `agentsociety2-v2.5.2`
+
+本版本在 [2.5.1] 基础上完成 **paper 技能外迁**、**安全加固** 与 **依赖漏洞修复**；Python 安装：`pip install agentsociety2==2.5.2`。
+
 ### Removed
 
 - **agentsociety2**：内置 `paper` 研究技能套件（`agentsociety-paper-adapter` / `agentsociety-paper-architecture` / `agentsociety-paper-evidence-architect`），论文生成迁移至独立的 `paper-toolkit` plugin。
@@ -22,6 +30,16 @@ Git 发版标签：`agentsociety2-v{major}.{minor}.{patch}`（见 `CONTRIBUTING.
 ### Changed
 
 - **docs**：根 `CLAUDE.md`、`workspace/CLAUDE.md`、`workspace/AGENTS.md` 指引由 `agentsociety-paper-orchestrator` 更新为引用外部 `paper-toolkit` plugin（确定性 CLI + companion Claude Code 写作 / 审阅 skill）。
+
+### Fixed
+
+- **agentsociety2**：后端路径解析增加 `..` / 空字节校验，消除 CodeQL 路径注入告警（`path_security.py`）。
+- **agentsociety2**：LLM Router 调试日志不再经含 API Key 的配置对象传递，避免敏感信息日志泄露。
+- **extension**：`.env` 写入时对 API Key 等值做完整转义（`\`、`"`、换行、`$` 等）。
+- **extension**：升级 `tmp`、`qs` 传递依赖，修复 `npm audit --audit-level=high` 失败。
+- **frontend**：升级 `fast-uri`、`fast-xml-builder`，并通过 `path-to-regexp` override 修复高危 npm 审计项。
+- **deps**：根 `uv.lock` 升级 `urllib3`、`idna`、`pytest`（仍使用清华 tuna 镜像源）。
+- **ci**：新增 CodeQL 配置，排除 `frontend/public/monaco-editor` 第三方 vendor 扫描误报。
 
 ---
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-social-scientist",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-social-scientist",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@ant-design/icons": "^5.2.0",
         "@ant-design/x": "^2.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-social-scientist",
   "displayName": "AI Social Scientist",
   "description": "AI Social Scientist - Next-generation human-AI interaction interface for social science research",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "publisher": "tsinghua-fib-lab",
   "repository": {
     "type": "git",

--- a/extension/src/envManager.ts
+++ b/extension/src/envManager.ts
@@ -267,15 +267,20 @@ export class EnvManager {
   /**
    * Format value for .env file
    */
-  private formatValue(value: any): string {
-    if (typeof value === 'string') {
-      // Escape if contains special characters
-      if (value.includes(' ') || value.includes('"') || value.includes("'") || value.includes('#')) {
-        return `"${value.replace(/"/g, '\\"')}"`;
-      }
+  private formatValue(value: unknown): string {
+    if (typeof value !== 'string') {
+      return String(value);
+    }
+    if (!/[\s"'#\\$`\n\r]/.test(value)) {
       return value;
     }
-    return String(value);
+    const escaped = value
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\$/g, '\\$');
+    return `"${escaped}"`;
   }
 
   /**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3035,9 +3035,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3052,9 +3049,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3069,9 +3063,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3086,9 +3077,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3103,9 +3091,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3120,9 +3105,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3137,9 +3119,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3154,9 +3133,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3171,9 +3147,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3188,9 +3161,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3205,9 +3175,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,9 +3189,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3239,9 +3203,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6838,9 +6799,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -6855,9 +6816,9 @@
       "peer": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -6866,7 +6827,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -8992,12 +8954,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pbf": {
@@ -12080,6 +12043,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xss": {
       "version": "1.0.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,5 +50,8 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
     "vite": "^6.0.1"
+  },
+  "overrides": {
+    "path-to-regexp": ">=8.4.2"
   }
 }

--- a/packages/agentsociety2/agentsociety2/backend/path_security.py
+++ b/packages/agentsociety2/agentsociety2/backend/path_security.py
@@ -10,8 +10,17 @@ _SAFE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 _ARTIFACT_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*\.md$")
 
 
+def _validated_user_path(path_str: str, *, field: str) -> Path:
+    if not path_str or "\0" in path_str:
+        raise HTTPException(status_code=400, detail=f"Invalid {field}")
+    candidate = Path(path_str)
+    if ".." in candidate.parts:
+        raise HTTPException(status_code=400, detail=f"Invalid {field}")
+    return candidate.expanduser().resolve()
+
+
 def resolve_workspace_root(workspace_path: str) -> Path:
-    root = Path(workspace_path).expanduser().resolve()
+    root = _validated_user_path(workspace_path, field="workspace_path")
     if not root.is_dir():
         raise HTTPException(
             status_code=404, detail=f"Workspace not found: {workspace_path}"
@@ -96,7 +105,7 @@ def require_safe_skill_name(name: str) -> str:
 
 
 def resolve_existing_directory(path_str: str) -> Path:
-    target = Path(path_str).expanduser().resolve()
+    target = _validated_user_path(path_str, field="path")
     if not target.is_dir():
         raise HTTPException(status_code=400, detail=f"Directory not found: {path_str}")
     return target
@@ -119,7 +128,7 @@ def resolve_skill_relative(skill_dir: Path, relative: str) -> Path:
 
 
 def resolve_path_under_directory(root: Path, path_str: str) -> Path:
-    target = Path(path_str).expanduser().resolve()
+    target = _validated_user_path(path_str, field="path")
     if target != root and root not in target.parents:
         raise HTTPException(status_code=400, detail="Path escapes allowed directory")
     return target

--- a/packages/agentsociety2/agentsociety2/config/config.py
+++ b/packages/agentsociety2/agentsociety2/config/config.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import re
 import uuid
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 from litellm.router import Router
 
 from agentsociety2.logger import get_logger, setup_litellm_logging
@@ -54,24 +54,6 @@ def _disable_mem0_capture_event() -> None:
 
 
 _disable_mem0_capture_event()
-
-
-def _router_model_names(model_list: list[dict[str, Any]]) -> list[str]:
-    return [str(entry.get("model_name", "")) for entry in model_list]
-
-
-def _redact_router_config_for_log(obj: Any) -> Any:
-    if isinstance(obj, dict):
-        out: dict[str, Any] = {}
-        for k, v in obj.items():
-            if k in ("api_key", "api_base") and isinstance(v, str) and v:
-                out[k] = (v[:4] + "…") if len(v) > 4 else "****"
-            else:
-                out[k] = _redact_router_config_for_log(v)
-        return out
-    if isinstance(obj, list):
-        return [_redact_router_config_for_log(x) for x in obj]
-    return obj
 
 
 # Initialize LiteLLM logging once
@@ -445,7 +427,10 @@ class Config:
             # Configure fallback chain: analysis -> default -> nano
             fallbacks = [{analysis_model: [default_model, nano_model]}]
 
-            logger.debug("Analysis router models: %s", _router_model_names(model_list))
+            logger.debug(
+                "Analysis router models: %s",
+                [analysis_model, default_model, nano_model],
+            )
             return Router(
                 model_list=model_list,
                 fallbacks=fallbacks,
@@ -514,7 +499,10 @@ class Config:
             # fallbacks should be a list of dicts, where each dict maps primary model to fallback models
             fallbacks = [{coder_model: [default_model, nano_model]}]
 
-            logger.debug("Coder router models: %s", _router_model_names(model_list))
+            logger.debug(
+                "Coder router models: %s",
+                [coder_model, default_model, nano_model],
+            )
             return Router(
                 model_list=model_list,
                 fallbacks=fallbacks,
@@ -565,7 +553,10 @@ class Config:
             # Configure fallback chain: default -> nano
             fallbacks = [{default_model: [nano_model]}]
 
-            logger.debug("Default router models: %s", _router_model_names(model_list))
+            logger.debug(
+                "Default router models: %s",
+                [default_model, nano_model],
+            )
             return Router(
                 model_list=model_list,
                 fallbacks=fallbacks,

--- a/packages/agentsociety2/pyproject.toml
+++ b/packages/agentsociety2/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentsociety2"
-version = "2.5.1"
+version = "2.5.2"
 description = "A modern, LLM-native agent simulation platform for social science research"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "agentsociety2"
-version = "2.4.1"
+version = "2.5.2"
 source = { editable = "packages/agentsociety2" }
 dependencies = [
     { name = "aiohttp" },
@@ -1615,11 +1615,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -3747,9 +3747,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -5122,11 +5122,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 架构调整

- 内置 paper 技能套件移除，论文生成改由外部 paper-toolkit plugin 负责
- 相关文档（CLAUDE.md 等）同步更新指引
- 安全加固

- 后端路径解析增加 .. / 空字节校验，修复路径注入风险
- LLM Router 调试日志不再泄露 API Key
- 扩展写入 .env 时对密钥做完整转义
- 依赖修复

- extension：修复 tmp、qs 高危漏洞（npm audit 通过）
- frontend：修复 fast-uri、fast-xml-builder、path-to-regexp 高危项
- Python：升级 urllib3、idna、pytest（uv.lock 仍用 tuna 源）

- CodeQL 排除 Monaco editor vendor 误报