### PR TITLE
fix(env): raise clear warning on unknown kwargs in EconomySpace

### DIFF
--- a/packages/agentsociety2/agentsociety2/contrib/env/economy_space.py
+++ b/packages/agentsociety2/agentsociety2/contrib/env/economy_space.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import warnings
 from datetime import datetime, timedelta
 from typing import ClassVar, List
 
@@ -99,13 +100,26 @@ class EconomySpace(EnvBase):
         ColumnDef("bank_interest_rate", "REAL"),
     ]
 
-    def __init__(self, persons: List[EconomyPerson] | List[dict]):
+   def __init__(self, persons: List[EconomyPerson] | List[dict], **kwargs):
         """
         Initialize the Economy Space environment.
 
         :param persons: List of persons to initialize the environment with. Can be EconomyPerson objects or dicts.
+        :param kwargs: Additional keyword arguments. Unknown arguments
+                 will trigger a warning.
         """
         super().__init__()
+
+       + # Warn about unsupported kwargs
+  if kwargs:
+      warnings.warn(
+          f"EconomySpace received unknown keyword arguments"
+          f" that will be ignored: {list(kwargs.keys())}. "
+          f"Please check your init_config.json for unsupported"
+          f" parameters under the economy environment config.",
+          UserWarning,
+          stacklevel=2,
+      )
 
         # Convert dict to EconomyPerson if needed
         person_objects = []


### PR DESCRIPTION
 Summary
EconomySpace currently silently ignores unknown keyword arguments passed during initialization (e.g., tax_rate in init_config.json). This causes user confusion when misconfigured parameters have no effect and produce no error feedback.

Problem
When users add unsupported parameters to the economy environment config in init_config.json, EconomySpace.__init__ only accepts persons and silently drops everything else.

 Changes
- Add **kwargs to EconomySpace.__init__ signature
- Emit a UserWarning listing all ignored keyword arguments
- Update docstring to document the kwargs parameter

Testing
1.Should emit warning about unknown kwargs
EconomySpace(persons=[...], tax_rate=0.05)
2.Should work normally without kwargs
EconomySpace(persons=[...])

## Summary

<!-- Briefly describe what this PR does and why. One or two sentences. -->

Closes #

## Changes

<!-- List the key changes. Be specific. -->

-

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] CI / Build

## Affected Modules

<!-- Check all that apply. -->

- [ ] Agent (`agentsociety2/agent/`)
- [ ] Agent Skills (`agentsociety2/agent/skills/`)
- [ ] Environment Router (`agentsociety2/env/`)
- [ ] Research Skills (`agentsociety2/skills/`)
- [ ] Backend API (`agentsociety2/backend/`)
- [ ] Storage (`agentsociety2/storage/`)
- [ ] CLI (`agentsociety2/society/cli.py`)
- [ ] Frontend (`frontend/`)
- [ ] Extension (`extension/`)
- [ ] Other: ___

## Testing

<!-- Describe how you verified your changes. -->

- [ ] Ran `uv run pytest` in `packages/agentsociety2`
- [ ] Ran `npm run lint` / `npm run build` in `extension` (if applicable)
- [ ] Ran `npm run lint` / `npm run build` in `frontend` (if applicable)
- [ ] Ran `npm audit --audit-level=high` (if JS deps changed)
- [ ] Manually tested
- [ ] Added / updated tests

## Checklist

- [ ] I have performed a self-review
- [ ] I have added docstrings where needed (following project conventions)
- [ ] I have updated relevant documentation
- [ ] My changes generate no new warnings
- [ ] I have checked for unintended breaking changes

## Notes for Reviewers

<!-- Anything reviewers should pay extra attention to? -->
