### PR TITLE
fix(agent): add missing _truncate_text static method to PersonAgent

### DIFF
--- a/packages/agentsociety2/agentsociety2/agent/person.py
+++ b/packages/agentsociety2/agentsociety2/agent/person.py
@@ -201,6 +201,13 @@ class PersonAgent(AgentBase):
         self._current_tool_span_id: str | None = None
         self._current_tool_started_at: float | None = None
 
+     @staticmethod
+    def _truncate_text(text: str, max_len: int = 3000) -> str:
+        """截断文本到指定长度"""
+        if len(text) <= max_len:
+            return text
+        return text[:max_len] + "...
+        
     def _update_workspace_cache(self, path: str, content: str) -> None:
         """更新缓存并执行 LRU 淘汰。
 


### PR DESCRIPTION
person.py 第 378 行调用了 _truncate_text，但这个方法没定义，
跑问卷步骤的时候会报 AttributeError。加了一个简单的截断方法，超过 3000 字符就截掉加 "..."   
复现：1. 运行 experiment，在问卷（questionnaire）步骤触发的 agent 响应时，   _build_external_question_context 方法会读取 workspace 里的文本文件   （state/observation.txt、state/thought.txt 等） 2. 当文本超过 3000 字符时，调用 self._truncate_text(text, max_len=3000) 截断 3. 方法不存在，直接抛出 AttributeError: 'PersonAgent' object has no attribute '_truncate_text'

## Summary

<!-- Briefly describe what this PR does and why. One or two sentences. -->

Closes #

## Changes

<!-- List the key changes. Be specific. -->

-

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] CI / Build

## Affected Modules

<!-- Check all that apply. -->

- [ ] Agent (`agentsociety2/agent/`)
- [ ] Agent Skills (`agentsociety2/agent/skills/`)
- [ ] Environment Router (`agentsociety2/env/`)
- [ ] Research Skills (`agentsociety2/skills/`)
- [ ] Backend API (`agentsociety2/backend/`)
- [ ] Storage (`agentsociety2/storage/`)
- [ ] CLI (`agentsociety2/society/cli.py`)
- [ ] Frontend (`frontend/`)
- [ ] Extension (`extension/`)
- [ ] Other: ___

## Testing

<!-- Describe how you verified your changes. -->

- [ ] Ran `uv run pytest` in `packages/agentsociety2`
- [ ] Ran `npm run lint` / `npm run build` in `extension` (if applicable)
- [ ] Ran `npm run lint` / `npm run build` in `frontend` (if applicable)
- [ ] Ran `npm audit --audit-level=high` (if JS deps changed)
- [ ] Manually tested
- [ ] Added / updated tests

## Checklist

- [ ] I have performed a self-review
- [ ] I have added docstrings where needed (following project conventions)
- [ ] I have updated relevant documentation
- [ ] My changes generate no new warnings
- [ ] I have checked for unintended breaking changes

## Notes for Reviewers

<!-- Anything reviewers should pay extra attention to? -->
