### PR TITLE
fix(agent): accept 'failed' as valid StructuredSummary status

### DIFF
--- a/packages/agentsociety2/agentsociety2/agent/context.py
+++ b/packages/agentsociety2/agentsociety2/agent/context.py
@@ -544,7 +544,7 @@ class StructuredSummary(BaseModel):
     """
 
     primary_goal: str = ""
-    current_status: Literal["in_progress", "completed", "blocked", "error"] = (
+    current_status: Literal["in_progress", "completed", "blocked", "error", "failed"] = (
         "in_progress"
     )
     completed_actions: list[str] = []


### PR DESCRIPTION
StructuredSummary.current_status 的 Pydantic Literal 只接受 'error'，但validate_plan_state.py 早已把 'failed' 列为合法状态——框架内部不一致。 在使用deepseekLLM 频繁输出 'failed'，导致实验在政策后观察阶段崩溃；使用千问LLM 没有出现这个现象 因此本次选择在 Literal 中添加 'failed' 以修复

## Summary

<!-- Briefly describe what this PR does and why. One or two sentences. -->

Closes #

## Changes

<!-- List the key changes. Be specific. -->

-

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] CI / Build

## Affected Modules

<!-- Check all that apply. -->

- [ ] Agent (`agentsociety2/agent/`)
- [ ] Agent Skills (`agentsociety2/agent/skills/`)
- [ ] Environment Router (`agentsociety2/env/`)
- [ ] Research Skills (`agentsociety2/skills/`)
- [ ] Backend API (`agentsociety2/backend/`)
- [ ] Storage (`agentsociety2/storage/`)
- [ ] CLI (`agentsociety2/society/cli.py`)
- [ ] Frontend (`frontend/`)
- [ ] Extension (`extension/`)
- [ ] Other: ___

## Testing

<!-- Describe how you verified your changes. -->

- [ ] Ran `uv run pytest` in `packages/agentsociety2`
- [ ] Ran `npm run lint` / `npm run build` in `extension` (if applicable)
- [ ] Ran `npm run lint` / `npm run build` in `frontend` (if applicable)
- [ ] Ran `npm audit --audit-level=high` (if JS deps changed)
- [ ] Manually tested
- [ ] Added / updated tests

## Checklist

- [ ] I have performed a self-review
- [ ] I have added docstrings where needed (following project conventions)
- [ ] I have updated relevant documentation
- [ ] My changes generate no new warnings
- [ ] I have checked for unintended breaking changes

## Notes for Reviewers

<!-- Anything reviewers should pay extra attention to? -->
